### PR TITLE
feat: add initial background messaging service

### DIFF
--- a/packages/background/package.json
+++ b/packages/background/package.json
@@ -25,7 +25,9 @@
     "@fetchai/blst-ts": "^0.3.1"
   },
   "dependencies": {
+    "eciesjs": "^0.3.15",
     "@cosmjs/launchpad": "^0.24.0-alpha.25",
+    "@cosmjs/encoding": "^0.24.0-alpha.25",
     "@cosmjs/proto-signing": "^0.24.0-alpha.25",
     "@ethersproject/bytes": "^5.5.0",
     "@ethersproject/keccak256": "^5.5.0",

--- a/packages/background/src/index.ts
+++ b/packages/background/src/index.ts
@@ -16,6 +16,7 @@ import * as Tokens from "./tokens/internal";
 import * as Interaction from "./interaction/internal";
 import * as Permission from "./permission/internal";
 import * as Umbral from "./umbral/internal";
+import * as Messaging from "./messaging/internal";
 
 export * from "./persistent-memory";
 export * from "./chains";
@@ -116,6 +117,9 @@ export function init(
 
   const umbralService = container.resolve(Umbral.UmbralService);
   Umbral.init(router, umbralService);
+
+  const messagingService = container.resolve(Messaging.MessagingService);
+  Messaging.init(router, messagingService);
 
   const backgroundTxService = container.resolve(
     BackgroundTx.BackgroundTxService

--- a/packages/background/src/messaging/constants.ts
+++ b/packages/background/src/messaging/constants.ts
@@ -1,0 +1,1 @@
+export const ROUTE = "messaging";

--- a/packages/background/src/messaging/handler.ts
+++ b/packages/background/src/messaging/handler.ts
@@ -1,0 +1,62 @@
+import { Env, Handler, InternalHandler, Message } from "@keplr-wallet/router";
+import {
+  DecryptMessagingMessage,
+  EncryptMessagingMessage,
+  GetMessagingPublicKey,
+} from "./messages";
+import { MessagingService } from "./service";
+
+export const getHandler: (service: MessagingService) => Handler = (service) => {
+  return (env: Env, msg: Message<unknown>) => {
+    switch (msg.constructor) {
+      case GetMessagingPublicKey:
+        return handleGetMessagingPublicKey(service)(
+          env,
+          msg as GetMessagingPublicKey
+        );
+
+      case EncryptMessagingMessage:
+        return handleEncryptMessagingMessage(service)(
+          env,
+          msg as EncryptMessagingMessage
+        );
+
+      case DecryptMessagingMessage:
+        return handleDecryptMessagingMessage(service)(
+          env,
+          msg as DecryptMessagingMessage
+        );
+      default:
+        throw new Error("Unknown msg type");
+    }
+  };
+};
+
+const handleGetMessagingPublicKey: (
+  service: MessagingService
+) => InternalHandler<GetMessagingPublicKey> = (service) => {
+  return async (env, msg) => {
+    return await service.getPublicKey(env, msg.chainId);
+  };
+};
+
+const handleEncryptMessagingMessage: (
+  service: MessagingService
+) => InternalHandler<EncryptMessagingMessage> = (service) => {
+  return async (env, msg) => {
+    return await service.encryptMessage(
+      env,
+      msg.chainId,
+      msg.targetAddress,
+      msg.message
+    );
+  };
+};
+
+const handleDecryptMessagingMessage: (
+  service: MessagingService
+) => InternalHandler<DecryptMessagingMessage> = (service) => {
+  return async (env, msg) => {
+    return await service.decryptMessage(env, msg.chainId, msg.cipherText);
+  };
+};

--- a/packages/background/src/messaging/handler.ts
+++ b/packages/background/src/messaging/handler.ts
@@ -3,6 +3,7 @@ import {
   DecryptMessagingMessage,
   EncryptMessagingMessage,
   GetMessagingPublicKey,
+  SignMessagingPayload,
 } from "./messages";
 import { MessagingService } from "./service";
 
@@ -25,6 +26,12 @@ export const getHandler: (service: MessagingService) => Handler = (service) => {
         return handleDecryptMessagingMessage(service)(
           env,
           msg as DecryptMessagingMessage
+        );
+
+      case SignMessagingPayload:
+        return handleSignMessagingPayload(service)(
+          env,
+          msg as SignMessagingPayload
         );
       default:
         throw new Error("Unknown msg type");
@@ -58,5 +65,13 @@ const handleDecryptMessagingMessage: (
 ) => InternalHandler<DecryptMessagingMessage> = (service) => {
   return async (env, msg) => {
     return await service.decryptMessage(env, msg.chainId, msg.cipherText);
+  };
+};
+
+const handleSignMessagingPayload: (
+  service: MessagingService
+) => InternalHandler<SignMessagingPayload> = (service) => {
+  return async (env, msg) => {
+    return await service.sign(env, msg.chainId, msg.payload);
   };
 };

--- a/packages/background/src/messaging/index.ts
+++ b/packages/background/src/messaging/index.ts
@@ -1,0 +1,2 @@
+export * from "./service";
+export * from "./messages";

--- a/packages/background/src/messaging/init.ts
+++ b/packages/background/src/messaging/init.ts
@@ -1,0 +1,17 @@
+import { Router } from "@keplr-wallet/router";
+import { ROUTE } from "./constants";
+import { getHandler } from "./handler";
+import { MessagingService } from "./service";
+import {
+  DecryptMessagingMessage,
+  EncryptMessagingMessage,
+  GetMessagingPublicKey,
+} from "./messages";
+
+export function init(router: Router, service: MessagingService): void {
+  router.registerMessage(GetMessagingPublicKey);
+  router.registerMessage(EncryptMessagingMessage);
+  router.registerMessage(DecryptMessagingMessage);
+
+  router.addHandler(ROUTE, getHandler(service));
+}

--- a/packages/background/src/messaging/init.ts
+++ b/packages/background/src/messaging/init.ts
@@ -6,12 +6,14 @@ import {
   DecryptMessagingMessage,
   EncryptMessagingMessage,
   GetMessagingPublicKey,
+  SignMessagingPayload,
 } from "./messages";
 
 export function init(router: Router, service: MessagingService): void {
   router.registerMessage(GetMessagingPublicKey);
   router.registerMessage(EncryptMessagingMessage);
   router.registerMessage(DecryptMessagingMessage);
+  router.registerMessage(SignMessagingPayload);
 
   router.addHandler(ROUTE, getHandler(service));
 }

--- a/packages/background/src/messaging/internal.ts
+++ b/packages/background/src/messaging/internal.ts
@@ -1,0 +1,2 @@
+export * from "./service";
+export * from "./init";

--- a/packages/background/src/messaging/messages.ts
+++ b/packages/background/src/messaging/messages.ts
@@ -79,3 +79,30 @@ export class DecryptMessagingMessage extends Message<string> {
     return DecryptMessagingMessage.type();
   }
 }
+
+export class SignMessagingPayload extends Message<string> {
+  public static type() {
+    return "sign-messaging-payload";
+  }
+
+  constructor(
+    public readonly chainId: string,
+    public readonly payload: string
+  ) {
+    super();
+  }
+
+  validateBasic(): void {
+    if (!this.chainId) {
+      throw new Error("Chain id is empty");
+    }
+  }
+
+  route(): string {
+    return ROUTE;
+  }
+
+  type(): string {
+    return DecryptMessagingMessage.type();
+  }
+}

--- a/packages/background/src/messaging/messages.ts
+++ b/packages/background/src/messaging/messages.ts
@@ -1,0 +1,81 @@
+import { Message } from "@keplr-wallet/router";
+import { ROUTE } from "../tokens/constants";
+
+export class GetMessagingPublicKey extends Message<string> {
+  public static type() {
+    return "get-messaging-public-key";
+  }
+
+  constructor(public readonly chainId: string) {
+    super();
+  }
+
+  validateBasic(): void {
+    if (!this.chainId) {
+      throw new Error("Chain id is empty");
+    }
+  }
+
+  route(): string {
+    return ROUTE;
+  }
+
+  type(): string {
+    return GetMessagingPublicKey.type();
+  }
+}
+
+export class EncryptMessagingMessage extends Message<string> {
+  public static type() {
+    return "encrypt-messaging-message";
+  }
+
+  constructor(
+    public readonly chainId: string,
+    public readonly targetAddress: string,
+    public readonly message: string
+  ) {
+    super();
+  }
+
+  validateBasic(): void {
+    if (!this.chainId) {
+      throw new Error("Chain id is empty");
+    }
+  }
+
+  route(): string {
+    return ROUTE;
+  }
+
+  type(): string {
+    return EncryptMessagingMessage.type();
+  }
+}
+
+export class DecryptMessagingMessage extends Message<string> {
+  public static type() {
+    return "decrypt-messaging-message";
+  }
+
+  constructor(
+    public readonly chainId: string,
+    public readonly cipherText: string
+  ) {
+    super();
+  }
+
+  validateBasic(): void {
+    if (!this.chainId) {
+      throw new Error("Chain id is empty");
+    }
+  }
+
+  route(): string {
+    return ROUTE;
+  }
+
+  type(): string {
+    return DecryptMessagingMessage.type();
+  }
+}

--- a/packages/background/src/messaging/service.ts
+++ b/packages/background/src/messaging/service.ts
@@ -1,0 +1,146 @@
+import { delay, inject, singleton } from "tsyringe";
+import { KeyRingService } from "../keyring";
+import { Env } from "@keplr-wallet/router";
+import { Hash } from "@keplr-wallet/crypto";
+import { decrypt, encrypt, PrivateKey } from "eciesjs";
+import { fromBase64, toBase64 } from "@cosmjs/encoding";
+
+@singleton()
+export class MessagingService {
+  private _publicKeyCache: Map<string, string>;
+
+  constructor(
+    @inject(delay(() => KeyRingService))
+    protected readonly keyRingService: KeyRingService
+  ) {
+    this._publicKeyCache = new Map<string, string>();
+  }
+
+  /**
+   * Lookup the public key associated with the messaging service
+   *
+   * @param env The extension environment
+   * @param chainId The target chain id
+   * @returns The base64 encoded compressed public key
+   */
+  public async getPublicKey(env: Env, chainId: string): Promise<string> {
+    const privateKey = await this.getPrivateKey(env, chainId);
+    return toBase64(privateKey.publicKey.compressed);
+  }
+
+  /**
+   * Decrypt a message that is targeted at the private key associated with the
+   * messaging service
+   *
+   * @param env The extention environment
+   * @param chainId The target chain id
+   * @param cipherText The base64 encoded cipher text to be processed
+   * @returns The base64 encoded clear text from the message
+   */
+  async decryptMessage(
+    env: Env,
+    chainId: string,
+    cipherText: string
+  ): Promise<string> {
+    const sk = await this.getPrivateKey(env, chainId);
+    const rawCipherText = Buffer.from(fromBase64(cipherText));
+
+    return toBase64(decrypt(sk.secret, rawCipherText));
+  }
+
+  /**
+   * Encrypt a message using the messaging protocol key
+   *
+   * @param env The extension environment
+   * @param chainId The target chain id
+   * @param targetAddress The target address
+   * @param message The base64 encoded message to be processed
+   * @returns The base64 encoded cipher text of the message
+   */
+  async encryptMessage(
+    _env: Env,
+    _chainId: string,
+    targetAddress: string,
+    message: string
+  ): Promise<string> {
+    const rawMessage = Buffer.from(fromBase64(message));
+    const targetPublicKey = await this.lookupPublicKey(targetAddress);
+
+    // encrypt the message
+    return toBase64(encrypt(targetPublicKey, rawMessage));
+  }
+
+  /**
+   * Lookup the public key for a target address
+   *
+   * Will first check the local cache, if not present will attempt to lookup the
+   * information from the memorandum service
+   *
+   * @param targetAddress The target address to find the public key for
+   * @returns The base64 encoded public key for the target address if successful
+   * @protected
+   */
+  protected async lookupPublicKey(targetAddress: string): Promise<string> {
+    // Step 1. Query the cache
+    let targetPublicKey = this._publicKeyCache.get(targetAddress);
+    if (targetPublicKey !== undefined) {
+      return targetPublicKey;
+    }
+
+    // Step 2. Cache miss, fetch the public key from the memorandum service and
+    //         update the cache
+    targetPublicKey = await this.fetchPublicKey(targetAddress);
+    this._publicKeyCache.set(targetAddress, targetPublicKey);
+
+    return targetPublicKey;
+  }
+
+  /**
+   * Fetch the public key information for a specificed address from the memorandum
+   * service
+   *
+   * @param targetAddress The address to lookup the public key for
+   * @returns The base64 encoded public key for the target address if successful
+   * @private
+   */
+  private async fetchPublicKey(_targetAddress: string): Promise<string> {
+    // TODO(EJF): Query the memorandum service for the public key associated with the target address
+    throw new Error(
+      "Not currently implemented - I need to query the memorandum service to lookup the public key"
+    );
+  }
+
+  /**
+   * Builds a private key from the signature of the current keychain
+   *
+   * @param env The environment of the extension
+   * @param chainId The target chain id
+   * @returns The generated private key object
+   * @private
+   */
+  private async getPrivateKey(env: Env, chainId: string): Promise<PrivateKey> {
+    const rawPrivateKey = Buffer.from(
+      Hash.sha256(
+        Buffer.from(
+          await this.keyRingService.sign(
+            env,
+            chainId,
+            Buffer.from(
+              JSON.stringify({
+                account_number: 0,
+                chain_id: chainId,
+                fee: [],
+                memo:
+                  "Create Messaging Signing Secret encryption key. Only approve requests by Keplr.",
+                msgs: [],
+                sequence: 0,
+              })
+            )
+          )
+        )
+      )
+    );
+
+    return new PrivateKey(rawPrivateKey);
+  }
+}

--- a/packages/background/src/messaging/service.ts
+++ b/packages/background/src/messaging/service.ts
@@ -1,7 +1,7 @@
 import { delay, inject, singleton } from "tsyringe";
 import { KeyRingService } from "../keyring";
 import { Env } from "@keplr-wallet/router";
-import { Hash } from "@keplr-wallet/crypto";
+import { Hash, PrivKeySecp256k1 } from "@keplr-wallet/crypto";
 import { decrypt, encrypt, PrivateKey } from "eciesjs";
 import { fromBase64, toBase64 } from "@cosmjs/encoding";
 
@@ -73,6 +73,28 @@ export class MessagingService {
 
     // encrypt the message
     return toBase64(encrypt(rawTargetPublicKey, rawMessage));
+  }
+
+  /**
+   * Sign the payload
+   *
+   * @param env The extension environment
+   * @param chainId The target chain id
+   * @param payload The base64 encoded payload that should be signed
+   * @returns The base64 encoded signature for the payload
+   */
+  async sign(env: Env, chainId: string, payload: string): Promise<string> {
+    const sk = await this.getPrivateKey(env, chainId);
+    const privateKey = new PrivKeySecp256k1(sk);
+
+    // decode the payload into raw bytes
+    const rawPayload = fromBase64(payload);
+
+    // sign the payload
+    const rawSignature = privateKey.sign(rawPayload);
+
+    // convert and return the signature
+    return toBase64(rawSignature);
   }
 
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -6181,6 +6181,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/secp256k1@^4.0.3":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@types/secp256k1/-/secp256k1-4.0.3.tgz#1b8e55d8e00f08ee7220b4d59a6abe89c37a901c"
+  integrity sha512-Da66lEIFeIz9ltsdMZcpQvmrmmoqrfju8pm1BH8WbYjZSwUgCwXLb9C+9XYogwBITnbsSaMdVPb2ekf7TV+03w==
+  dependencies:
+    "@types/node" "*"
+
 "@types/sha.js@^2.4.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@types/sha.js/-/sha.js-2.4.0.tgz#bce682ef860b40f419d024fa08600c3b8d24bb01"
@@ -11155,6 +11162,15 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
+eciesjs@^0.3.15:
+  version "0.3.15"
+  resolved "https://registry.yarnpkg.com/eciesjs/-/eciesjs-0.3.15.tgz#614fd3251a72c063b6a0a9a8dbbfe89aafc94b7a"
+  integrity sha512-8hMcxjgUCSyastAK+BkFAzojRR/wqJNUkp20a0Yw8PudTSeHB57kjcl9x2jkaTVCG2NJwSTdJkM6RcUpqnY+Zw==
+  dependencies:
+    "@types/secp256k1" "^4.0.3"
+    futoin-hkdf "^1.5.1"
+    secp256k1 "^4.0.3"
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
@@ -13050,6 +13066,11 @@ functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
+
+futoin-hkdf@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/futoin-hkdf/-/futoin-hkdf-1.5.1.tgz#141f00427bc9950b38a42aa786b99c318b9b688d"
+  integrity sha512-g5d0Qp7ks55hYmYmfqn4Nz18XH49lcCR+vvIvHT92xXnsJaGZmY1EtWQWilJ6BQp57heCIXM/rRo+AFep8hGgg==
 
 gauge@^4.0.0:
   version "4.0.3"
@@ -22284,6 +22305,15 @@ secp256k1@^4.0.1, secp256k1@^4.0.2:
   integrity sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==
   dependencies:
     elliptic "^6.5.2"
+    node-addon-api "^2.0.0"
+    node-gyp-build "^4.2.0"
+
+secp256k1@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/secp256k1/-/secp256k1-4.0.3.tgz#c4559ecd1b8d3c1827ed2d1b94190d69ce267303"
+  integrity sha512-NLZVf+ROMxwtEj3Xa562qgv2BK5e2WNmXPiOdVIPLgs6lyTzMvBq0aWTYMI5XCP9jZMVKOcqZLw/Wc4vDkuxhA==
+  dependencies:
+    elliptic "^6.5.4"
     node-addon-api "^2.0.0"
     node-gyp-build "^4.2.0"
 


### PR DESCRIPTION
## Overview

Added a new messaging service to the background service. This should be accessible inside the extension in the standard way.
Ultimately this service derives a public / private keypair from the standard keyring and uses this for all messaging cryptography

New messaging types added to support the 4 new main functions of the service:

- GetMessagingPublicKey - *allows the extension to query the current public key*
- EncryptMessagingMessage - *allows the extension to request an encryption of arbitruary data*
- DecryptMessagingMessage - *allows the extension to request a decryption of arbitruary data*
- SignMessagingPayload - *allows the extension to request a signature for arbitruary data*

### Notes

- I have kept the API for all the above messages relatively generic, initially to aid understanding. It might be a better idea to push more of the messaging specific datastructures into the API to make it more specific.

### Outstanding tasks

- [ ] Testing! - *while it builds and I believe the basic logic is about right, I have not done really any testing*
- [ ] Ledger support - *related to above, Ledger based devices should be supported with the messaging service but this is something to double check.*
- [ ] There are a lot of things missing from the implementation, two big ones are:
  1. implement the correct API calls from inside the messaging service to be able to lookup the required public key from the memorandum service
  2. implement the registration of the messaging public key with the memorandum service

